### PR TITLE
Add Docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+.venv
+sample_db_record.txt
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+# Install system dependencies for PySpark
+RUN apt-get update \
+    && apt-get install -y openjdk-11-jre-headless build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+# Install Python dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
+
+COPY . /app
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+ENTRYPOINT []
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 A streaming preprocessing app and monitoring tool for fire events on earth.
 ![Architecture of application](images/architecture.png)
 
-
 ## Some functionalities:
 1. When a fire event is streamed to the app, it classifies the event as either man-made or natural by comparing the geohash of the event location.
 2. The app stores the classification result together with the fire event record on MongoDB for later analysis/visualization.
-3. To simulate the incoming weather data and fire data, we created three servers and Kafka producers. 
+3. To simulate the incoming weather data and fire data, we created three servers and Kafka producers.
 
 ## Note on running the app:
 - change host ip
@@ -22,6 +21,13 @@ Use [uv](https://github.com/astral-sh/uv) to manage Python dependencies:
 uv pip install -r uv.lock
 ```
 
-## TODO
-- add dockerfile and docker-compose file
+## Docker
+The project includes a `Dockerfile` and `docker-compose.yml` for running the
+application together with Kafka and MongoDB. Build and start the services with:
 
+```bash
+docker compose up --build
+```
+
+This command builds the application image and launches MongoDB, Kafka, and
+producer containers all at once.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - '2181:2181'
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+
+  mongo:
+    image: mongo:6
+    restart: always
+    ports:
+      - '27017:27017'
+    volumes:
+      - mongo-data:/data/db
+
+  app:
+    build: .
+    command: python main.py
+    depends_on:
+      - kafka
+      - mongo
+    environment:
+      - PYSPARK_PYTHON=python
+      - PYSPARK_DRIVER_PYTHON=python
+    ports:
+      - '4040:4040'
+
+  producer1:
+    build: .
+    command: python producer1.py
+    depends_on:
+      - kafka
+
+  producer2:
+    build: .
+    command: python producer2.py
+    depends_on:
+      - kafka
+
+  producer3:
+    build: .
+    command: python producer3.py
+    depends_on:
+      - kafka
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- add Dockerfile to build the python/spark image
- add docker-compose configuration with Kafka, MongoDB and producers
- ignore python cache files in docker context
- document Docker usage in README
- use uv image and sync dependencies in Dockerfile
- clarify docker compose instructions and ignore venv sample data

## Testing
- `python -m py_compile main.py producer1.py producer2.py producer3.py create_mongodb.py live_visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_684736e7cd5c832687aea22f506d2be6